### PR TITLE
Added the minimum X's required for mktemp

### DIFF
--- a/update
+++ b/update
@@ -2,7 +2,7 @@
 
 set -e
 
-tmp=$(mktemp -t freemail)
+tmp=$(mktemp -t freemailXXX)
 cat ./data/blacklist.txt \
     | sed '/./,$!d' \
     | sed -e 's/^ *//' -e 's/ *$//' \
@@ -11,7 +11,7 @@ cat ./data/blacklist.txt \
     | uniq > $tmp
 mv $tmp ./data/blacklist.txt
 
-tmp=$(mktemp -t freemail)
+tmp=$(mktemp -t freemailXXX)
 cat ./data/free.txt \
     | sed '/./,$!d' \
     | sed -e 's/^ *//' -e 's/ *$//' \
@@ -21,7 +21,7 @@ cat ./data/free.txt \
     | comm -23 - ./data/blacklist.txt > $tmp
 mv $tmp ./data/free.txt
 
-tmp=$(mktemp -t freemail)
+tmp=$(mktemp -t freemailXXX)
 cat ./data/disposable.txt \
     | sed '/./,$!d' \
     | sed -e 's/^ *//' -e 's/ *$//' \
@@ -33,12 +33,12 @@ cat ./data/disposable.txt \
 mv $tmp ./data/disposable.txt
 
 sources=$(cat ./data/sources.txt)
-new=$(mktemp -t freemail)
+new=$(mktemp -t freemailXXX)
 for source in $sources; do
     echo "$(curl --silent $source)" >> $new
 done;
 
-tmp=$(mktemp -t freemail)
+tmp=$(mktemp -t freemailXXX)
 cat $new \
     | sed '/./,$!d' \
     | sed -e 's/^ *//' -e 's/ *$//' \
@@ -49,7 +49,7 @@ cat $new \
     | comm -23 - ./data/free.txt \
     | comm -23 - ./data/disposable.txt > $tmp
 
-confirmed=$(mktemp -t freemail)
+confirmed=$(mktemp -t freemailXXX)
 for domain in $(cat $tmp); do
     result=`dig +short mx $domain`
     if [ -n "$result" ]; then
@@ -57,7 +57,7 @@ for domain in $(cat $tmp); do
     fi
 done
 
-tmp=$(mktemp -t freemail)
+tmp=$(mktemp -t freemailXXX)
 cat $confirmed ./data/free.txt \
     | sort \
     | uniq > $tmp


### PR DESCRIPTION
According to the documentation of `mktemp`, the

        TEMPLATE must contain at least 3 consecutive 'X's in last component.

I have added them there.