### PR TITLE
Add python bindings and package info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+*.pyc

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A database of free and [disposable](http://en.wikipedia.org/wiki/Disposable_email_address)
 email domains and a handy Node.js module for querying it.
 
-Use the Node.js module or access the files in the `./data` directory and parse
+Install via npm or pip or access the files in the `./data` directory and parse
 with your language of choice.
 
 In an effort to create the most up-to-date list of domains, the database can be
@@ -48,4 +48,24 @@ freemail.isDisposable('smith@gmail.com');
 freemail.isDisposable('jack@mailinater.com');
 > true
 
+```
+
+## Python
+
+### Install
+
+```
+pip install freemail
+```
+
+```python
+>>> import freemail
+>>> freemail.is_free('jack@mailinater.com')
+True
+>>> freemail.is_free('jack@mailinater.com')
+True
+>>> freemail.is_disposable('smith@gmail.com')
+False
+>>> freemail.is_disposable('jack@mailinater.com')
+True
 ```

--- a/freemail/__init__.py
+++ b/freemail/__init__.py
@@ -1,0 +1,35 @@
+import tldextract
+import subprocess
+
+free_file = './data/free.txt'
+disp_file = './data/disposable.txt'
+
+
+def is_free(email_address):
+    if not isinstance(email_address, str):
+        raise TypeError('email must be a string')
+
+    with open(free_file, 'r') as free, open(disp_file, 'r') as disposable:
+        domain_list = free.read().splitlines() + disposable.read().splitlines()
+        domain = tldextract.extract(email_address.split('@')[1]).registered_domain
+
+        return domain in domain_list
+
+
+def is_disposable(email_address):
+    if not isinstance(email_address, str):
+        raise TypeError('email must be a string')
+
+    with open(disp_file, 'r') as disposable:
+        domain_list = disposable.read().splitlines()
+        domain = tldextract.extract(email_address.split('@')[1]).registered_domain
+
+        return domain in domain_list
+
+
+def update():
+    try:
+        subprocess.call("./update", shell=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,83 @@
+"""A setuptools based setup module.
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='freemail',
+
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='1.2.0',
+
+    description='A database of free and disposable email domains',
+    long_description=long_description,
+
+    # The project's main homepage.
+    url='https://github.com/wearespindle/freemail',
+    download_url='https://github.com/wearespindle/freemail',
+    # Author details
+    author='Devhouse Spindle',
+    author_email='info@wearespindle.com',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        # How mature is this project?
+        #   1 - Planning
+        #   2 - Pre-Alpha
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        #   6 - Mature
+        #   7 - Inactive
+        'Development Status :: 4 - Beta',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+    ],
+
+    # What does your project relate to?
+    keywords='email',
+
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages=['freemail', ],
+    data_files=[
+        ('freemail', ['update', ]),
+        ('freemail/data', ['data/free.txt', 'data/disposable.txt', ]),
+    ],
+
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=[
+        'tldextract'
+    ],
+
+    # List additional groups of dependencies here (e.g. development
+    # dependencies). You can install these using the following syntax,
+    # for example:
+    # $ pip install -e .[dev,test]
+    extras_require={},
+    test_suite=''
+)


### PR DESCRIPTION
I've created python bindings in the same manner as your node.js bindings. I don't know if you want to have more bindings in the project, if not it's okay we will maintain our fork. Just wanted you to have the choice :)

There's a setup.py you can use to register it on pypi. Depending on whether you want to merge this back in I can also register it (didn't do it just yet because I don't know if you can transfer a package to a different owner on pypi).