### PR TITLE
Add Sky ISP's free email domain

### DIFF
--- a/data/free.txt
+++ b/data/free.txt
@@ -3184,6 +3184,7 @@ singpost.com
 skafan.com
 skim.com
 skizo.hu
+sky.com
 slamdunkfan.com
 slingshot.com
 slotter.com


### PR DESCRIPTION
Sky operates a broadband and free email service in the UK. They provide an email address in the format username@sky.com

Source: https://www.sky.com/help/articles/get-emails-on-your-windows-desktop-client

Sky corporate email addresses seem to use the format username@sky.uk : https://corporate.sky.com/media-centre/contact-us