### PR TITLE
Add lackmail.ru to the disposable list

### DIFF
--- a/data/disposable.txt
+++ b/data/disposable.txt
@@ -122,6 +122,7 @@ killmail.net
 klassmaster.com
 klzlk.com
 kurzepost.de
+lackmail.ru
 lhsdv.com
 lifebyfood.com
 link2mail.net


### PR DESCRIPTION
From the [lackmail.ru website](http://lackmail.ru/):
> This is free public temp mail service used only for incoming email testing by developers without registration.
> 
> Keep in mind:
> - Sending email from our servers are completely DISABLED;
> - Our servers can only receive email and store it for only one hour;
> - If you think that email was sent from our servers and used for fraud: Please kindly check email headers!