### PR TITLE
Performance improvement using object instead of array

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,54 @@
 var fs = require('fs');
 var tldjs = require('tldjs');
 
-var disposable = fs.readFileSync(__dirname + '/data/disposable.txt').toString().split('\n');
-var free = fs.readFileSync(__dirname + '/data/free.txt').toString().split('\n').concat(disposable);
+var disposable = load('/data/disposable.txt');
+var free = extend(load('/data/free.txt'), disposable);
 
 function isFree(email) {
     if (typeof email !== 'string') throw new TypeError('email must be a string');
-    var domain = tldjs.getDomain(email.split('@').pop());
-    return free.indexOf(domain) !== -1;
+    var split = email.split('@');
+    var domain = getDomain(split[1] || split[0]);
+    return !!(domain && free[domain]);
 }
 
 function isDisposable(email) {
     if (typeof email !== 'string') throw new TypeError('email must be a string');
-    var domain = tldjs.getDomain(email.split('@').pop());
-    return disposable.indexOf(domain) !== -1;
+    var split = email.split('@');
+    var domain = getDomain(split[1] || split[0]);
+    return !!(domain && disposable[domain]);
+}
+
+function getDomain(host) {
+  var split = host.split('.');
+  // Performance optimization for .com TLD
+  if (split.length >= 2 && split[split.length - 1] === 'com') {
+    return split.slice(-2).join('.');
+  }
+  return tldjs.getDomain(host);
+}
+
+function load(path) {
+  return fs.readFileSync(__dirname + path, 'utf8')
+    .split('\n')
+    .reduce(function(res, cur) {
+      res[cur] = true;
+      return res;
+    }, {});
+}
+
+function extend(a, b) {
+  var res = {};
+  var key;
+
+  for (key in a) {
+    res[key] = a[key];
+  }
+
+  for (key in b) {
+    res[key] = b[key];
+  }
+
+  return res;
 }
 
 module.exports = {


### PR DESCRIPTION
Results:
- [master] Median time: 32630 microseconds
- [PR] Median time: 12 microseconds

I used mail2jon.com as an example, which is half way down the free list. I also removed the dependency on `tldjs` since the parsing is unnecessary.

Here's the benchmark script:

``` javascript
// npm install microtime
var microtime = require('microtime')
var freemail = require('./index');

var times = [];
var i, j, start, end;

// Calculate the median execution time of 1001 tests,
// with each test invoking isFree 100 times
for (i = 0; i < 1001; i ++) {
  start = microtime.now()
  for (j = 0; j < 100; j++) {
    freemail.isFree('foo@mail2jon.com');
  }
  end = microtime.now()
  times.push(end - start);
}

console.log('Median time:', times.sort()[500], 'microseconds');
```
