### PR TITLE
Add alicedsl.de to free list

### DIFF
--- a/data/free.txt
+++ b/data/free.txt
@@ -133,6 +133,7 @@ algeria.com
 alhilal.net
 alibaba.com
 alice.it
+alicedsl.de
 alive.cz
 aliyun.com
 allergist.com


### PR DESCRIPTION
Alice (now O2) is a large ISP in Germany. They used to provide free mail addresses to their customers. These addresses are still widely used.

I don't think there are any new addresses issued since the brand is not in active use anymore (in Germany at least). But still, we should add the domain here.