### PR TITLE
Remove comcast.com (corporate domain)

### DIFF
--- a/data/free.txt
+++ b/data/free.txt
@@ -507,7 +507,6 @@ colleges.com
 columbus.rr.com
 columbusrr.com
 columnist.com
-comcast.com
 comcast.net
 comic.com
 communityconnect.com


### PR DESCRIPTION
Looks like comcast.com is the corporate domain for comcast (source: https://www.quora.com/How-does-comcast-com-differ-from-comcast-net)