### PR TITLE
Add pokemail.net to disposable.txt

### DIFF
--- a/data/disposable.txt
+++ b/data/disposable.txt
@@ -214,6 +214,7 @@ otherinbox.com
 ovpn.to
 owlpic.com
 pancakemail.com
+pokemail.net
 politikerclub.de
 poofy.org
 pookmail.com


### PR DESCRIPTION
Pokemail advertises itself [as a disposable email provider](https://www.pokemail.net/about):

>PokeMail! gives you a disposable email address that is tied to a location. There is no need to register, simply visit PokeMail! and set your location.