### PR TITLE
exclude easypost.com from freelist

### DIFF
--- a/data/blacklist.txt
+++ b/data/blacklist.txt
@@ -2,3 +2,4 @@
 .findhere.com
 .freeservers.com
 .zzn.com
+easypost.com

--- a/data/free.txt
+++ b/data/free.txt
@@ -752,7 +752,6 @@ earthonline.net
 eastcoast.co.za
 eastmail.com
 easy.to
-easypost.com
 eatmydirt.com
 ecardmail.com
 ecbsolutions.net


### PR DESCRIPTION
My company's domain was used as free mail hosting about 15 years ago, but has belonged to my company (which provides shipping and logistics services, not free email) for the last 10 years. Unfortunately, it's still on a bunch of these "free email providers" lists and we periodically run into services that won't let us sign up for accounts. We've traced a few of those back to this NPM module.

You can see from https://www.easypost.com that we are not and never have been in the business of providing free email hosting.

I know it's kind of tilting at windmills, but I figured it wouldn't hurt to try to get out of this node module.