### PR TITLE
remove mailinblack.com

### DIFF
--- a/data/free.txt
+++ b/data/free.txt
@@ -2976,7 +2976,6 @@ mailgenie.net
 mailhaven.com
 mailhood.com
 mailinatorzz.mooo.com
-mailinblack.com
 mailingaddress.org
 mailingweb.com
 mailisent.com


### PR DESCRIPTION
mailinblack.com isn't a free email domain, it is the corporate domain of Mailinblack an email protection provider.